### PR TITLE
remove apt-transport-https

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Deprecated (no longer updated) distributions include:
 
 As root (`sudo -s`), enter the following commands, after making sure you have lsb_release installed:
 
-```
+```ShellSession
 wget -O /etc/apt/trusted.gpg.d/wsl-transdebian.gpg https://arkane-systems.github.io/wsl-transdebian/apt/wsl-transdebian.gpg
 
 chmod a+r /etc/apt/trusted.gpg.d/wsl-transdebian.gpg

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Deprecated (no longer updated) distributions include:
 As root (`sudo -s`), enter the following commands, after making sure you have lsb_release installed:
 
 ```
-apt install apt-transport-https
-
 wget -O /etc/apt/trusted.gpg.d/wsl-transdebian.gpg https://arkane-systems.github.io/wsl-transdebian/apt/wsl-transdebian.gpg
 
 chmod a+r /etc/apt/trusted.gpg.d/wsl-transdebian.gpg


### PR DESCRIPTION
apt-transport-https is no longer required on recents versions.

The description of the package says:

Description: transitional package for https support
 This is a dummy transitional package - https support has been moved into
 the apt package in 1.5. It can be safely removed.